### PR TITLE
feat: add InteractablePreset.InteractionKey property to input detection event args

### DIFF
--- a/SOD.Common/Helpers/InputDetection.cs
+++ b/SOD.Common/Helpers/InputDetection.cs
@@ -5,25 +5,28 @@ namespace SOD.Common.Helpers
     public sealed class InputDetection
     {
         internal InputDetection() { }
+
         /// <summary>
         /// Raised when a button's state changes from up/released to down/pressed and vice versa.
         /// </summary>
         public event EventHandler<InputDetectionEventArgs> OnButtonStateChanged;
 
-        internal void ReportButtonStateChange(string actionName, bool isDown)
+        internal void ReportButtonStateChange(string actionName, InteractablePreset.InteractionKey key, bool isDown)
         {
-            OnButtonStateChanged?.Invoke(this, new InputDetectionEventArgs(actionName, isDown));
+            OnButtonStateChanged?.Invoke(this, new InputDetectionEventArgs(actionName, key, isDown));
         }
     }
 
     public sealed class InputDetectionEventArgs : EventArgs
     {
         public string ActionName { get; }
+        public InteractablePreset.InteractionKey Key { get; }
         public bool IsDown { get; }
 
-        internal InputDetectionEventArgs(string actionName, bool isDown)
+        internal InputDetectionEventArgs(string actionName, InteractablePreset.InteractionKey key, bool isDown)
         {
             ActionName = actionName;
+            Key = key;
             IsDown = isDown;
         }
     }


### PR DESCRIPTION
Enables this functionality:
```cs
Lib.InputDetection.OnButtonStateChanged += OnButtonStateChanged;

private void OnButtonStateChanged(object sender, InputDetectionEventArgs e) {
    // added e.Key, so you don't have to use a string like "Primary"
    // only works for InteractablePreset.InteractionKey enum entries
    if (e.Key == InteractablePreset.InteractionKey.LeanLeft && e.IsDown) {
        // stuff
    }
    if (e.Key == InteractablePreset.InteractionKey.LeanRight && e.IsDown) {
        // stuff
    }
    if (e.Key == InteractablePreset.InteractionKey.flashlight) {
        // stuff
    }
}
```

Note: There were two of these "keyenuminputdetection" feature branches... I was confused about why my branch was 3 commits behind but I don't think it's anything I did.