### PR TITLE
Feature/plugindetectionhelpers

### DIFF
--- a/SOD.Common/Helpers/PluginDetection.cs
+++ b/SOD.Common/Helpers/PluginDetection.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using BepInEx;
 using BepInEx.Configuration;
 using BepInEx.Unity.IL2CPP;
+using Il2CppSystem.Runtime.InteropServices;
 using UniverseLib;
 
 namespace SOD.Common.Helpers
@@ -17,7 +18,7 @@ namespace SOD.Common.Helpers
 
         /// <summary>
         /// True if the BepInEx chainloader has finished loading all plugins,
-        /// false otherwise (is set to true after OnAllPluginsFinishedLoading).
+        /// false otherwise (is set to true after <c>OnAllPluginsFinishedLoading</c>).
         /// </summary>
         public bool AllPluginsFinishedLoading { get; private set; } = false;
 
@@ -38,7 +39,7 @@ namespace SOD.Common.Helpers
         /// across all loaded plugins.
         /// </summary>
         /// <remarks>
-        /// Should be called in response to Lib.BepInEx.OnAllPluginsFinishedLoading.
+        /// Should be called in response to <c>OnAllPluginsFinishedLoading</c>.
         /// Useful for plugins such as Babbler, which use a prefix on their
         /// GUID to influence load order.
         /// </remarks>
@@ -73,18 +74,39 @@ namespace SOD.Common.Helpers
         /// name, etc.) of a BepInEx plugin given its GUID.
         /// </summary>
         /// <remarks>
-        /// Should be called in response to Lib.BepInEx.OnAllPluginsFinishedLoading.
+        /// Should be called in response to <c>OnAllPluginsFinishedLoading</c>.
+        /// </remarks>
+        /// <param name="pluginGuid">The GUID of the target plugin.</param>
+        /// <param name="info">The BepInEx PluginInfo data object of the target
+        /// plugin.</param>
+        /// <returns></returns>
+        public bool TryGetPluginInfo(string pluginGuid, out PluginInfo info) => IL2CPPChainloader.Instance.Plugins.TryGetValue(pluginGuid, out info);
+
+        /// <summary>
+        /// Gets the plugin info (incompatibilities, version, user-friendly
+        /// name, etc.) of a BepInEx plugin given its GUID.
+        /// </summary>
+        /// <remarks>
+        /// Should be called in response to <c>OnAllPluginsFinishedLoading</c>.
         /// </remarks>
         /// <param name="pluginGuid">The GUID of the target plugin.</param>
         /// <returns>The plugin's info.</returns>
-        public PluginInfo GetPluginInfo(string pluginGuid) => IL2CPPChainloader.Instance.Plugins[pluginGuid];
+        /// <exception cref="System.Collections.Generic.KeyNotFoundException"></exception>
+        public PluginInfo GetPluginInfo(string pluginGuid)
+        {
+            if (!TryGetPluginInfo(pluginGuid, out var info))
+            {
+                throw new System.Collections.Generic.KeyNotFoundException($"Plugin GUID ({pluginGuid}) not found.");
+            }
+            return info;
+        }
 
         /// <summary>
         /// Gets the currently assigned value of a specified config setting for
         /// a BepInEx plugin given its GUID.
         /// </summary>
         /// <remarks>
-        /// Should be called in response to Lib.BepInEx.OnAllPluginsFinishedLoading.
+        /// Should be called in response to <c>OnAllPluginsFinishedLoading</c>.
         /// </remarks>
         /// <typeparam name="T">The config entry value type.</typeparam>
         /// <param name="pluginGuid">The GUID of the target plugin.</param>
@@ -110,7 +132,7 @@ namespace SOD.Common.Helpers
         /// respond to changes in the config settings of other plugins.
         /// </summary>
         /// <remarks>
-        /// Should be called in response to Lib.BepInEx.OnAllPluginsFinishedLoading.
+        /// Should be called in response to <c>OnAllPluginsFinishedLoading</c>.
         /// </remarks>
         /// <param name="pluginGuid">The GUID of the target plugin.</param>
         /// <param name="listener">The action to be called in response to a

--- a/SOD.Common/Helpers/PluginDetection.cs
+++ b/SOD.Common/Helpers/PluginDetection.cs
@@ -57,7 +57,7 @@ namespace SOD.Common.Helpers
         public string GetPluginGuidFromPartialGuid(string partialPluginGuid)
         {
             var guids = IL2CPPChainloader.Instance.Plugins.Keys;
-            var matches = guids.Where(guid => guid.ToLower().Contains(partialPluginGuid.ToLower()));
+            var matches = guids.Where(guid => guid.ToLower().Contains(partialPluginGuid.ToLower())).ToArray();
             int matchCount = matches.Count();
             if (matchCount == 0)
             {

--- a/SOD.Common/Helpers/PluginDetection.cs
+++ b/SOD.Common/Helpers/PluginDetection.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Linq;
+using BepInEx;
+using BepInEx.Configuration;
+using BepInEx.Unity.IL2CPP;
+using UniverseLib;
+
+namespace SOD.Common.Helpers
+{
+    public sealed class PluginDetection
+    {
+        public event EventHandler OnAllPluginsFinishedLoading;
+        public bool AllPluginsFinishedLoading { get; private set; } = false;
+        private bool _initialized = false;
+
+        public PluginDetection()
+        {
+            Initialize();
+        }
+
+        internal void Initialize()
+        {
+            if (_initialized)
+            {
+                return;
+            }
+            _initialized = true;
+
+            var invokeEventAction = () => OnAllPluginsFinishedLoading?.Invoke(this, EventArgs.Empty);
+            IL2CPPChainloader.Instance.Finished += invokeEventAction;
+            IL2CPPChainloader.Instance.Finished += () => { AllPluginsFinishedLoading = true; };
+        }
+
+        /// <summary>
+        /// Get the full GUID of a plugin by searching for a partial GUID
+        /// across all loaded plugins.
+        /// </summary>
+        /// <remarks>
+        /// Should be called in response to Lib.BepInEx.OnAllPluginsFinishedLoading.
+        /// Useful for plugins such as Babbler, which use a prefix on their
+        /// GUID to influence load order.
+        /// </remarks>
+        /// <param name="partialPluginGuid">A partial GUID.</param>
+        /// <returns></returns>
+        /// <exception cref="System.InvalidOperationException"></exception>
+        public string GetPluginGuidFromPartialGuid(string partialPluginGuid)
+        {
+            var guids = IL2CPPChainloader.Instance.Plugins.Keys;
+            var matches = guids.Where(guid => guid.ToLower().Contains(partialPluginGuid.ToLower()));
+            int matchCount = matches.Count();
+            if (matchCount == 0)
+            {
+                return null;
+            }
+            if (matchCount > 1)
+            {
+                throw new System.InvalidOperationException($"Multiple GUIDs match the provided partial GUID ({partialPluginGuid}): {string.Join(", ", matches)}.");
+            }
+            return matches.First();
+        }
+
+        /// <summary>
+        /// Check if a BepInEx plugin is loaded given the plugin GUID.
+        /// </summary>
+        /// <param name="pluginGuid">The GUID of the target plugin.</param>
+        /// <returns>True if the plugin has been loaded, false otherwise.</returns>
+        public bool IsPluginLoaded(string pluginGuid) => IL2CPPChainloader.Instance.Plugins.ContainsKey(pluginGuid);
+
+        /// <summary>
+        /// Gets the plugin info (incompatibilities, version, user-friendly
+        /// name, etc.) of a BepInEx plugin given its GUID.
+        /// </summary>
+        /// <remarks>
+        /// Should be called in response to Lib.BepInEx.OnAllPluginsFinishedLoading.
+        /// </remarks>
+        /// <param name="pluginGuid">The GUID of the target plugin.</param>
+        /// <returns>The plugin's info.</returns>
+        public PluginInfo GetPluginInfo(string pluginGuid) => IL2CPPChainloader.Instance.Plugins[pluginGuid];
+
+        /// <summary>
+        /// Gets the currently assigned value of a specified config setting for
+        /// a BepInEx plugin given its GUID.
+        /// </summary>
+        /// <remarks>
+        /// Should be called in response to Lib.BepInEx.OnAllPluginsFinishedLoading.
+        /// </remarks>
+        /// <typeparam name="T">The config entry value type.</typeparam>
+        /// <param name="pluginGuid">The GUID of the target plugin.</param>
+        /// <param name="section">The section of the config file where the
+        /// target config setting resides.</param>
+        /// <param name="key">The name of the target config setting.</param>
+        /// <returns>The current value of the target config setting.</returns>
+        /// <exception cref="System.InvalidOperationException"></exception>
+        public T GetPluginConfigEntryValue<T>(string pluginGuid, string section, string key)
+        {
+            var info = GetPluginInfo(pluginGuid);
+            var plugin = (BasePlugin)info.Instance.TryCast(typeof(BasePlugin));
+            if (!plugin.Config.TryGetEntry<T>(section: section, key: key, entry: out var entry))
+            {
+                throw new System.InvalidOperationException($"No configuration entry found for ({section}, {key}).");
+            }
+            return entry.Value;
+        }
+
+        /// <summary>
+        /// Adds a listener to the SettingChanged event handler of a BepInEx
+        /// plugin's configuration manager given its GUID. Allows plugins to
+        /// respond to changes in the config settings of other plugins.
+        /// </summary>
+        /// <remarks>
+        /// Should be called in response to Lib.BepInEx.OnAllPluginsFinishedLoading.
+        /// </remarks>
+        /// <param name="pluginGuid">The GUID of the target plugin.</param>
+        /// <param name="listener">The action to be called in response to a
+        /// change in target plugin config settings.</param>
+        public void AddPluginConfigEntryChangedListener(string pluginGuid, Action<SettingChangedEventArgs> listener)
+        {
+            var info = GetPluginInfo(pluginGuid);
+            var plugin = (BasePlugin)info.Instance.TryCast(typeof(BasePlugin));
+            plugin.Config.SettingChanged += (_, args) => listener(args);
+        }
+    }
+}

--- a/SOD.Common/Helpers/PluginDetection.cs
+++ b/SOD.Common/Helpers/PluginDetection.cs
@@ -50,7 +50,7 @@ namespace SOD.Common.Helpers
         {
             var guids = IL2CPPChainloader.Instance.Plugins.Keys;
             var matches = guids.Where(guid => guid.ToLower().Contains(partialPluginGuid.ToLower())).ToArray();
-            int matchCount = matches.Count();
+            int matchCount = matches.Length;
             if (matchCount == 0)
             {
                 return null;

--- a/SOD.Common/Helpers/PluginDetection.cs
+++ b/SOD.Common/Helpers/PluginDetection.cs
@@ -21,25 +21,16 @@ namespace SOD.Common.Helpers
         /// </summary>
         public bool AllPluginsFinishedLoading { get; private set; } = false;
 
-        private bool _initialized = false;
-
         internal PluginDetection()
         {
-            Initialize();
+            IL2CPPChainloader.Instance.Finished += OnAllPluginsFinishedLoadingListener;
         }
 
-        internal void Initialize()
+        private void OnAllPluginsFinishedLoadingListener()
         {
-            if (_initialized)
-            {
-                return;
-            }
-            _initialized = true;
-
-            // Hook up the OnAllPluginsFinishedLoading event and related
-            var invokeEventAction = () => OnAllPluginsFinishedLoading?.Invoke(this, EventArgs.Empty);
-            IL2CPPChainloader.Instance.Finished += invokeEventAction;
-            IL2CPPChainloader.Instance.Finished += () => { AllPluginsFinishedLoading = true; };
+            AllPluginsFinishedLoading = true;
+            OnAllPluginsFinishedLoading?.Invoke(this, EventArgs.Empty);
+            IL2CPPChainloader.Instance.Finished -= OnAllPluginsFinishedLoadingListener;
         }
 
         /// <summary>

--- a/SOD.Common/Lib.cs
+++ b/SOD.Common/Lib.cs
@@ -46,5 +46,10 @@ namespace SOD.Common
         /// Contains helper methods regarding player to npc dialog.
         /// </summary>
         public static Dialog Dialog { get; } = new Dialog();
+
+        /// <summary>
+        /// Contains helpers to detect loaded BepInEx plugins and their config settings.
+        /// </summary>
+        public static PluginDetection PluginDetection { get; } = new PluginDetection();
     }
 }


### PR DESCRIPTION
Let me know if you would prefer custom exceptions instead of how I approached it.

Example code:
```cs
Lib.PluginDetection.OnAllPluginsFinishedLoading += DetectPlugins;

// ...

private void DetectPlugins(object sender, EventArgs e) {
    var guid = Lib.PluginDetection.GetPluginGuidFromPartialGuid("Dialog");

    Log.LogInfo(Lib.PluginDetection.IsPluginLoaded(guid));
    Log.LogInfo(Lib.PluginDetection.AllPluginsFinishedLoading);

    BepInPlugin metadata = Lib.PluginDetection.GetPluginInfo(guid).Metadata;
    Log.LogInfo(metadata.GUID);
    Log.LogInfo(metadata.Name);
    Log.LogInfo(metadata.Version);

    var value = Lib.PluginDetection.GetPluginConfigEntryValue<bool>(guid, "Talk to Partner", "Can asking for the partner fail?");
    Log.LogInfo(value);

    // To respond to in-game changes in plugin config
    Lib.PluginDetection.AddPluginConfigEntryChangedListener(guid, DialogAdditionsConfigSettingChanged);
}

private void DialogAdditionsConfigSettingChanged(SettingChangedEventArgs args) {
    Log.LogInfo(args.ChangedSetting.Definition.Section);
    Log.LogInfo(args.ChangedSetting.Definition.Key);
    Log.LogInfo(args.ChangedSetting.Description.Description);
    if (args.ChangedSetting.Definition.Key == "Example") {
        var value = (float)args.ChangedSetting.BoxedValue;
        // ...
    }
}
```