### PR TITLE
Improve connections for wallets and employment contracts

### DIFF
--- a/Mods/SOD.QoL/Patches/ToolboxPatches.cs
+++ b/Mods/SOD.QoL/Patches/ToolboxPatches.cs
@@ -43,6 +43,14 @@ namespace SOD.QoL.Patches
                         });
                     }
                 }
+
+                if (Plugin.Instance.Config.EmploymentContractLinksResidence) {
+                    if (Toolbox.Instance.evidencePresetDictionary.TryGetValue("employmentcontract",
+                            out var employmentContractPreset))
+                    {
+                        employmentContractPreset.addFactLinks[0].subject = EvidencePreset.FactLinkSubject.writer;
+                    }
+                }
             }
         }
     }

--- a/Mods/SOD.QoL/Patches/ToolboxPatches.cs
+++ b/Mods/SOD.QoL/Patches/ToolboxPatches.cs
@@ -34,6 +34,13 @@ namespace SOD.QoL.Patches
                         {
                             walletPreset.keyMergeOnDiscovery[0].mergeKeys.Add(Evidence.DataKey.address);
                         }
+                        walletPreset.addFactLinks.Add(new EvidencePreset.FactLinkSetup
+                        {
+                            discovery = true,
+                            factDictionary = "LivesAt",
+                            subject = EvidencePreset.FactLinkSubject.writer,
+                            key = Evidence.DataKey.name
+                        });
                     }
                 }
             }


### PR DESCRIPTION
Have wallets and employment contracts establish connections between an NPC's evidence item and the corresponding evidence item for their place of residence.